### PR TITLE
Restore Django 1.8/1.9 compatibility, and allow caching of Falsey values

### DIFF
--- a/django_request_cache/__init__.py
+++ b/django_request_cache/__init__.py
@@ -30,6 +30,9 @@ def cache_calculate_key(*args, **kwargs):
     return str(key)
 
 
+NO_CACHE_RESULT = 'NO_CACHE_RESULT'
+
+
 def cache_for_request(fn):
     """
     Decorator that allows to cache a function call with parameters and its result only for the current request
@@ -47,9 +50,9 @@ def cache_for_request(fn):
 
         # cache found -> check if a result is already available for this function call
         key = cache_calculate_key(fn.__name__, *args, **kwargs)
-        result = getattr(cache, key, None)
+        result = getattr(cache, key, NO_CACHE_RESULT)
 
-        if not result:
+        if result == NO_CACHE_RESULT:
             # no result available -> execute function
             result = fn(*args, **kwargs)
             setattr(cache, key, result)

--- a/django_request_cache/middleware.py
+++ b/django_request_cache/middleware.py
@@ -1,7 +1,7 @@
 from django.core.cache.backends.base import BaseCache
 from django.core.cache.backends.locmem import LocMemCache
-from django.utils.deprecation import MiddlewareMixin
 from django.utils.synch import RWLock
+from django_userforeignkey.middleware import MiddlewareMixin
 
 # Attribution: RequestCache and RequestCacheMiddleware are from a source code snippet on StackOverflow
 # https://stackoverflow.com/questions/3151469/per-request-cache-in-django/37015573#37015573


### PR DESCRIPTION
- Existing dependency django_userforeignkey offers the means to maintain django 1.8/1.9 compatibility for relatively little cost
- If a cache_for_request function attempts to cache a falsey response, e,g, `0`, `False`, `[]` then it will previously attempt to re-fetch the result each time and the cache benefit will be lost.